### PR TITLE
Add missing man pages for arista-gtk and arista-transcode

### DIFF
--- a/man/arista-gtk.1
+++ b/man/arista-gtk.1
@@ -1,0 +1,49 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ARISTA-GTK 1 "July 16, 2009"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+arista-gtk \-  graphical interface for Arista Transcoder
+.SH SYNOPSIS
+.B arista-gtk
+.SH DESCRIPTION
+This manual page documents briefly the
+.B arista-gtk
+command.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+.\" respectively.
+\fBarista\fP is a multimedia transcoder for the GNOME Desktop which allows
+user to encode audio and video streams for a wide variety of devices.
+.PP
+.B arista-gtk
+provides a simple user interface for the
+.B arista-transcode
+command.
+.PP
+.B arista-gtk
+has been written with Python and GTK+2, and after installing the application
+you can run it from the
+.B Applications
+menu.
+.SH SEE ALSO
+.BR arista-transcode (1).
+.SH AUTHOR
+arista-gtk was written by Daniel G. Taylor <dan@programmer-art.org>.
+.PP
+This manual page was written by Alessio Treglia <quadrispro@ubuntu.com>,
+for the Ubuntu project (and may be used by others).

--- a/man/arista-transcode.1
+++ b/man/arista-transcode.1
@@ -1,0 +1,83 @@
+.\"                                      Hey, EMACS: -*- nroff -*-
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ARISTA-TRANSCODE 1 "July 16, 2009"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+arista-transcode \-  multimedia transcoding tool for the GNOME Desktop
+.SH SYNOPSIS
+.B arista-transcode
+.RI [ options ] " infile outfile" ...
+.SH DESCRIPTION
+This manual page documents briefly the
+.B arista-transcode
+command.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics,
+.\" respectively.
+\fBarista\fP is a multimedia transcoder for the GNOME Desktop which allows
+user to encode audio and video streams for a wide variety of devices.
+.PP
+.B arista-transcode
+is a command line program which allows user to encode audio and video stream
+for various devices.
+.PP
+Features include automatic discovery of DVD media and V4L devices, ripping
+from DVD or files, a live quality preview, and included presets for the
+most popular devices currently in use.
+.SH OPTIONS
+This program follows the usual GNU command line syntax, with long
+options starting with two dashes (`-').
+.TP
+.B \-h, \-\-help
+Show summary of options.
+.TP
+.B \-v, \-\-version
+Show version of program.
+.TP
+.B \-i, \-\-info
+Show information about available devices.
+.TP
+.B \-S SUBTITLE, \-\-subtitle=SUBTITLE
+Subtitle file to render.
+.TP
+.B \-f FONT, \-\-font=FONT
+Font to use when rendering subtitles.
+.TP
+.B \-p PRESET, \-\-preset=PRESET
+Preset to encode to [default].
+.TP
+.B \-d DEVICE, \-\-device=DEVICE
+Device to encode to [computer].
+.TP
+.B \-s, \-\-source-info
+Show information about input file and exit.
+.TP
+.B \-q, \-\-quiet
+Don't show status and time remaining.
+.TP
+.B -v, \-\-verbose
+Show verbose (debug) output.
+.TP 
+.B \-u, \-\-update
+Check for and download updated device presets if they are available
+.SH SEE ALSO
+.BR arista-gtk (1).
+.SH AUTHOR
+arista-transcode was written by Daniel G. Taylor <dan@programmer-art.org>.
+.PP
+This manual page was written by Alessio Treglia <quadrispro@ubuntu.com>,
+for the Ubuntu project (and may be used by others).

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ if not hasattr(DistributionMetadata, "zip_safe"):
 
 data_files = [
     (os.path.join("share", "applications"), ["arista.desktop"]),
+    (os.path.join("share", "man/man1"), [
+        "man/arista-gtk.1", "man/arista-transcode.1"]),
     (os.path.join("share", "doc", "arista"), [
         "README.md", "LICENSE", "AUTHORS"
     ]),


### PR DESCRIPTION
Hi
When building arista on the Open Build Service I get missing man pages RPMLINT warnings. Since man pages are available on http://manpages.ubuntu.com/manpages/oneiric/ I asked the author if it was ok to upstream to you for inclusion, which is fine by him.

I have updated the setup.py to include as required.
