### PR TITLE
Fix crash when no camera-video icon is available

### DIFF
--- a/arista-gtk
+++ b/arista-gtk
@@ -1288,8 +1288,11 @@ class AddDialog(object):
                 
                 for device, capture in self.finder.capture_devices.items():
                     iter = model.append()
-                    model.set_value(iter, 0, theme.load_icon("camera-video",
+                    try:
+                        model.set_value(iter, 0, theme.load_icon("camera-video",
                                                              size, 0))
+                    except:
+                        pass
                     model.set_value(iter, 1, capture.nice_label)
                     if capture.version == '1':
                         model.set_value(iter, 2, ("v4l://" + device, True))


### PR DESCRIPTION
Arista crashes when a v4l device exists but the icon theme has no "camera-video" icon.

https://bugs.launchpad.net/ubuntu/+source/arista/+bug/814911
